### PR TITLE
fix: ad video `playsinline` attribute to follow content

### DIFF
--- a/src/utils/helpers.ts
+++ b/src/utils/helpers.ts
@@ -21,6 +21,7 @@ export function createAdVideoElement(
   adVideoElement.style.backgroundColor = "black";
   adVideoElement.style.display = "none";
   if (contentVideoElement) {
+    adVideoElement.playsInline = contentVideoElement.playsInline;
     adVideoElement.muted = contentVideoElement.muted;
     adVideoElement.volume = contentVideoElement.volume;
   }


### PR DESCRIPTION
This PR adds the `playsinline` attribute on the ad video element if the content video element has it set.