### PR TITLE
Migrate to media-event-filter

### DIFF
--- a/demo/index.html
+++ b/demo/index.html
@@ -12,9 +12,9 @@
   <div id="wrapper">
 
     <script async type="text/javascript"
-      src="https://unpkg.com/@eyevinn/web-player-component@0.6.1/dist/web-player.component.js"></script>
+      src="https://unpkg.com/@eyevinn/web-player-component@0.8.10/dist/web-player.component.js"></script>
     <eyevinn-video
-      source="https://redbee.ctl.cdn.ebsd.ericsson.net/eyevinn/stswe/assets/aebaa3f0-1065-11ea-9384-053acb2c6404_29C72F/materials/3lpMXs9fnr_29C72F/vod-idx.ism/.m3u8?"
+      source="https://bitmovin-a.akamaihd.net/content/MI201109210084_1/m3u8s/f08e80da-bf1d-4e3d-8899-f0f6155f6efa.m3u8"
       muted autoplay></eyevinn-video>
 
       <!-- live video -->

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
       "dependencies": {
         "@dailymotion/vast-client": "^4.0.0",
         "@dailymotion/vmap": "^3.3.0",
-        "@eyevinn/video-event-filter": "^2.0.0",
+        "@eyevinn/media-event-filter": "1.0.4",
         "mitt": "^3.0.0"
       },
       "devDependencies": {
@@ -173,18 +173,10 @@
         "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
       }
     },
-    "node_modules/@eyevinn/video-event-filter": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@eyevinn/video-event-filter/-/video-event-filter-2.0.0.tgz",
-      "integrity": "sha512-S5pECmymqg7WqlAeerhtPVEFxWhLY3cz3DTuhuljZreVDLnEBV6/DlWI6SWDnKdpDJMgD6VjPfaRJssmGatNBg==",
-      "dependencies": {
-        "mitt": "^2.1.0"
-      }
-    },
-    "node_modules/@eyevinn/video-event-filter/node_modules/mitt": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/mitt/-/mitt-2.1.0.tgz",
-      "integrity": "sha512-ILj2TpLiysu2wkBbWjAmww7TkZb65aiQO+DkVdUTBpBXq+MHYiETENkKFMtsJZX1Lf4pe4QOrTSjIfUwN5lRdg=="
+    "node_modules/@eyevinn/media-event-filter": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@eyevinn/media-event-filter/-/media-event-filter-1.0.4.tgz",
+      "integrity": "sha512-jqpJgorPvop05HeE1Km1Unbs1ypm9Jq5qyGj25U5l0ECP4KbvV9hgDS145zBwb9hG9fIhoVl/50Qb2kDt/yuzQ=="
     },
     "node_modules/@humanwhocodes/config-array": {
       "version": "0.9.5",
@@ -4125,20 +4117,10 @@
         "strip-json-comments": "^3.1.1"
       }
     },
-    "@eyevinn/video-event-filter": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@eyevinn/video-event-filter/-/video-event-filter-2.0.0.tgz",
-      "integrity": "sha512-S5pECmymqg7WqlAeerhtPVEFxWhLY3cz3DTuhuljZreVDLnEBV6/DlWI6SWDnKdpDJMgD6VjPfaRJssmGatNBg==",
-      "requires": {
-        "mitt": "^2.1.0"
-      },
-      "dependencies": {
-        "mitt": {
-          "version": "2.1.0",
-          "resolved": "https://registry.npmjs.org/mitt/-/mitt-2.1.0.tgz",
-          "integrity": "sha512-ILj2TpLiysu2wkBbWjAmww7TkZb65aiQO+DkVdUTBpBXq+MHYiETENkKFMtsJZX1Lf4pe4QOrTSjIfUwN5lRdg=="
-        }
-      }
+    "@eyevinn/media-event-filter": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@eyevinn/media-event-filter/-/media-event-filter-1.0.4.tgz",
+      "integrity": "sha512-jqpJgorPvop05HeE1Km1Unbs1ypm9Jq5qyGj25U5l0ECP4KbvV9hgDS145zBwb9hG9fIhoVl/50Qb2kDt/yuzQ=="
     },
     "@humanwhocodes/config-array": {
       "version": "0.9.5",

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
   "dependencies": {
     "@dailymotion/vast-client": "^4.0.0",
     "@dailymotion/vmap": "^3.3.0",
-    "@eyevinn/video-event-filter": "^2.0.0",
+    "@eyevinn/media-event-filter": "1.0.4",
     "mitt": "^3.0.0"
   },
   "devDependencies": {


### PR DESCRIPTION
`@eyevinn/video-event-filter` has been deprecated

This PR aims to move the previous event listener structure into the callback structure of the new filter.

Migration is untested since I've been unable to get the demo page into a working state (both pre- and post-changes). I don't think merging this PR without testing first is a good idea.